### PR TITLE
feat: Add toolbar theme switcher with menu sync

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,6 +282,28 @@ ipcMain.handle('get-config', async () => {
   }
 });
 
+// IPC handler to update config
+ipcMain.handle('update-config', async (event, configUpdate) => {
+  try {
+    // Read current config
+    let config = { buttons: [] };
+    if (fs.existsSync(configPath)) {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    }
+    
+    // Merge the update with existing config
+    config = { ...config, ...configUpdate };
+    
+    // Write back to file
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log('Config updated successfully:', configUpdate);
+    return true;
+  } catch (e) {
+    console.error('Error updating config:', e);
+    return false;
+  }
+});
+
 // Persist button order sent from renderer to config.json
 ipcMain.on('save-button-order', (event, orderedIds) => {
   try {
@@ -1666,6 +1688,15 @@ app.whenReady().then(() => {
     ] },
     { label: 'Tools', submenu: [
       { label: 'Developer Tools', accelerator: 'F12', click: () => { if (win && !win.isDestroyed()) win.webContents.toggleDevTools(); } },
+      { type: 'separator' },
+      { label: 'Themes', submenu: [
+        { id: 'theme_dark', label: '🌙 Dark', type: 'radio', checked: true, click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'dark'); } },
+        { id: 'theme_light', label: '☀️ Light', type: 'radio', click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'light'); } },
+        { id: 'theme_red', label: '❤️ Red', type: 'radio', click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'red'); } },
+        { id: 'theme_purple', label: '💜 Purple', type: 'radio', click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'purple'); } },
+        { id: 'theme_blue', label: '💙 Blue', type: 'radio', click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'blue'); } },
+        { id: 'theme_darkpop', label: '🎵 Dark Pop', type: 'radio', click: () => { if (win && !win.isDestroyed()) win.webContents.send('theme-change', 'darkpop'); } }
+      ] },
       { role: 'reload' }
     ] },
     { label: 'Help', submenu: [ { label: 'About', click: () => {
@@ -1697,6 +1728,34 @@ app.whenReady().then(() => {
       });
     } catch (e) {
       console.warn('Failed to sync view prefs to menu:', e);
+    }
+  });
+
+  // Listen for theme changes from renderer and sync menu radio states
+  ipcMain.on('sync-theme', (event, themeName) => {
+    try {
+      const menu = Menu.getApplicationMenu();
+      if (!menu) return;
+      
+      // Clear all theme radio buttons
+      const themeIds = ['theme_dark', 'theme_light', 'theme_red', 'theme_purple', 'theme_blue', 'theme_darkpop'];
+      themeIds.forEach(themeId => {
+        const mi = menu.getMenuItemById ? menu.getMenuItemById(themeId) : null;
+        if (mi && typeof mi.checked !== 'undefined') {
+          mi.checked = false;
+        }
+      });
+      
+      // Set the active theme
+      const activeThemeId = `theme_${themeName}`;
+      const activeMenuItem = menu.getMenuItemById ? menu.getMenuItemById(activeThemeId) : null;
+      if (activeMenuItem && typeof activeMenuItem.checked !== 'undefined') {
+        activeMenuItem.checked = true;
+      }
+      
+      console.log('Synced theme menu to:', themeName);
+    } catch (e) {
+      console.error('Error syncing theme menu:', e);
     }
   });
 

--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onTriggerMedia: (callback) => ipcRenderer.on('trigger-media', (event, mediaId) => callback(mediaId)),
   onRefreshUI: (callback) => ipcRenderer.on('refresh-ui', (event) => callback()),
   getConfig: async () => ipcRenderer.invoke('get-config'),
+  updateConfig: async (configUpdate) => ipcRenderer.invoke('update-config', configUpdate),
   // Return persisted Twitch Client config (tc_config.json in userData)
   getTwitchConfig: async () => ipcRenderer.invoke('get-tc-config'),
   getSoundPath: async (relativePath) => ipcRenderer.invoke('get-sound-path', relativePath),
@@ -64,4 +65,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onViewHideAll: (callback) => ipcRenderer.on('view-hide-all', callback),
   onViewToggle: (callback) => ipcRenderer.on('view-toggle', (event, payload) => callback(payload)),
   syncViewPrefs: (prefs) => ipcRenderer.send('sync-view-prefs', prefs),
+  onThemeChange: (callback) => ipcRenderer.on('theme-change', (event, themeName) => callback(themeName)),
+  syncTheme: (themeName) => ipcRenderer.send('sync-theme', themeName),
 });

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
 <body>
   <div id="global-drop-zone" class="hidden">Drop files here</div>
   
+
   <!-- Component Visibility Dropdown -->
   <div id="visibility-dropdown" class="visibility-dropdown visibility-menu hidden">
     <button id="visibility-toggle" class="visibility-toggle-btn">⚙️ Components</button>
@@ -48,6 +49,9 @@
     <img src="logo.png" alt="Virtual Deck Logo" class="app-logo" />
     <div class="hotkey-info">
       <strong>Numpad Currently Not supported</strong>
+      <div class="hotkey-help">
+        <small>💡 Tip: Press Ctrl+Shift+T to cycle through themes</small>
+      </div>
     </div>
     <button id="twitch-connect" class="twitch-btn"></button>
     

--- a/public/script.js
+++ b/public/script.js
@@ -2815,3 +2815,200 @@ typeSelect.addEventListener('change', function() {
     appFileInput.required = true;
   }
 });
+
+// Theme System
+class ThemeManager {
+  constructor() {
+    this.currentTheme = 'dark';
+    this.themes = ['dark', 'light', 'red', 'purple', 'blue', 'darkpop'];
+    this.storageKey = 'virtualdeck-theme-v1'; // Versioned key to avoid conflicts
+    this.init().catch(console.error);
+  }
+
+  async init() {
+    await this.loadSavedTheme();
+    this.setupEventListeners();
+    this.applyTheme(this.currentTheme);
+    
+    // Ensure theme is applied after delays to handle any timing issues
+    setTimeout(() => {
+      this.applyTheme(this.currentTheme);
+    }, 100);
+    
+    // Apply again after a longer delay to ensure it sticks
+    setTimeout(() => {
+      this.applyTheme(this.currentTheme);
+    }, 500);
+    
+    // Sync the menu state with the loaded theme
+    setTimeout(() => {
+      if (window.electronAPI?.syncTheme) {
+        window.electronAPI.syncTheme(this.currentTheme);
+      }
+    }, 600);
+  }
+
+  async loadSavedTheme() {
+    try {
+      let savedTheme = null;
+      
+      // Try Electron API first (production)
+      if (window.electronAPI?.getConfig) {
+        try {
+          const config = await window.electronAPI.getConfig();
+          savedTheme = config?.theme;
+        } catch (error) {
+          savedTheme = localStorage.getItem(this.storageKey);
+        }
+      } else {
+        // Fallback to localStorage (development)
+        savedTheme = localStorage.getItem(this.storageKey);
+      }
+      
+      if (savedTheme && this.themes.includes(savedTheme)) {
+        this.currentTheme = savedTheme;
+      }
+    } catch (error) {
+      // Use default theme on error
+    }
+  }
+
+  setupEventListeners() {
+    // Listen for theme changes from the menu bar
+    if (window.electronAPI?.onThemeChange) {
+      window.electronAPI.onThemeChange((themeName) => {
+        this.setTheme(themeName);
+      });
+    }
+  }
+
+  setTheme(themeName) {
+    if (this.themes.includes(themeName)) {
+      this.currentTheme = themeName;
+      this.applyTheme(themeName);
+      this.saveTheme(themeName);
+      
+      // Sync the menu state
+      if (window.electronAPI?.syncTheme) {
+        window.electronAPI.syncTheme(themeName);
+      }
+    }
+  }
+
+  applyTheme(themeName) {
+    // Set the theme attribute on document and body
+    document.documentElement.setAttribute('data-theme', themeName);
+    document.body.setAttribute('data-theme', themeName);
+    
+    // Force a style recalculation to ensure the theme is applied
+    document.documentElement.style.display = 'none';
+    document.documentElement.offsetHeight; // Trigger reflow
+    document.documentElement.style.display = '';
+  }
+
+
+  saveTheme(themeName) {
+    try {
+      // Try Electron API first (production)
+      if (window.electronAPI?.updateConfig) {
+        window.electronAPI.updateConfig({ theme: themeName });
+      } else {
+        // Fallback to localStorage (development)
+        localStorage.setItem(this.storageKey, themeName);
+      }
+    } catch (error) {
+      // Try localStorage as fallback
+      try {
+        localStorage.setItem(this.storageKey, themeName);
+      } catch (localError) {
+        // Silent fail if both methods fail
+      }
+    }
+  }
+
+  getCurrentTheme() {
+    return this.currentTheme;
+  }
+
+  // Method to cycle through themes (useful for hotkeys)
+  cycleTheme() {
+    const currentIndex = this.themes.indexOf(this.currentTheme);
+    const nextIndex = (currentIndex + 1) % this.themes.length;
+    this.setTheme(this.themes[nextIndex]);
+  }
+}
+
+// Initialize theme manager
+let themeManager;
+
+// Apply theme immediately to prevent flash
+(function applyThemeImmediately() {
+  const storageKey = 'virtualdeck-theme-v1';
+  const oldKey = 'virtualdeck-theme';
+  
+  // Check both new and old keys
+  let savedTheme = localStorage.getItem(storageKey);
+  
+  if (!savedTheme) {
+    savedTheme = localStorage.getItem(oldKey);
+    if (savedTheme) {
+      localStorage.setItem(storageKey, savedTheme);
+      localStorage.removeItem(oldKey);
+    }
+  }
+  
+  if (savedTheme && ['dark', 'light', 'red', 'purple', 'blue', 'darkpop'].includes(savedTheme)) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+    
+    // Sync menu state after a delay to ensure Electron API is ready
+    setTimeout(() => {
+      if (window.electronAPI?.syncTheme) {
+        window.electronAPI.syncTheme(savedTheme);
+      }
+    }, 100);
+  }
+})();
+
+// Wait for DOM to be ready before initializing theme manager
+document.addEventListener('DOMContentLoaded', () => {
+  themeManager = new ThemeManager();
+  
+  // Add hotkey to cycle through themes (Ctrl+Shift+T)
+  document.addEventListener('keydown', (e) => {
+    if (e.ctrlKey && e.shiftKey && e.key === 'T') {
+      e.preventDefault();
+      if (themeManager) {
+        themeManager.cycleTheme();
+      }
+    }
+  });
+  
+  // Export for potential use by other parts of the app
+  window.themeManager = themeManager;
+  
+  // Watch for any changes to the document element's data-theme attribute
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        if (currentTheme !== themeManager.getCurrentTheme()) {
+          setTimeout(() => {
+            themeManager.applyTheme(themeManager.getCurrentTheme());
+          }, 10);
+        }
+      }
+    });
+  });
+  
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme']
+  });
+  
+  // Final theme application after everything else has loaded
+  window.addEventListener('load', () => {
+    setTimeout(() => {
+      themeManager.applyTheme(themeManager.getCurrentTheme());
+    }, 1000);
+  });
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,7 +1,7 @@
 /* public/styles.css */
 body {
-  background: #111;
-  color: white;
+  background: var(--bg-primary);
+  color: var(--text-primary);
   font-family: sans-serif;
   margin: 0;
   padding: 0;
@@ -11,11 +11,231 @@ body {
   min-height: 100vh;
   width: 100vw;
   overflow: auto; /* allow the grid to grow and the page to scroll */
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 :root {
   --card-size: 110px; /* width and height of each sound card */
   --card-gap: 12px;   /* gap between cards */
+  
+  /* Theme Variables - Default Dark Theme */
+  --bg-primary: #111;
+  --bg-secondary: #1a1a1a;
+  --bg-tertiary: #222;
+  --bg-quaternary: #2a2a2a;
+  --bg-quinary: #333;
+  
+  --text-primary: #ffffff;
+  --text-secondary: #cccccc;
+  --text-tertiary: #aaaaaa;
+  --text-quaternary: #888888;
+  
+  --border-primary: #444444;
+  --border-secondary: #555555;
+  --border-tertiary: #666666;
+  --border-quaternary: #777777;
+  
+  --accent-primary: #4CAF50;
+  --accent-secondary: #2e86de;
+  --accent-tertiary: #ff6b6b;
+  --accent-quaternary: #ffcc00;
+  
+  --hover-bg: #444444;
+  --active-bg: #555555;
+  --focus-bg: #666666;
+  
+  --shadow-color: rgba(0, 0, 0, 0.3);
+  --shadow-hover: rgba(0, 0, 0, 0.5);
+  
+  --success-color: #4CAF50;
+  --warning-color: #ff9800;
+  --error-color: #f44336;
+  --info-color: #2196F3;
+}
+
+/* Light Theme */
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --bg-tertiary: #eeeeee;
+  --bg-quaternary: #e0e0e0;
+  --bg-quinary: #d0d0d0;
+  
+  --text-primary: #212121;
+  --text-secondary: #424242;
+  --text-tertiary: #616161;
+  --text-quaternary: #757575;
+  
+  --border-primary: #e0e0e0;
+  --border-secondary: #d0d0d0;
+  --border-tertiary: #bdbdbd;
+  --border-quaternary: #9e9e9e;
+  
+  --accent-primary: #4CAF50;
+  --accent-secondary: #2196F3;
+  --accent-tertiary: #ff5722;
+  --accent-quaternary: #ff9800;
+  
+  --hover-bg: #f0f0f0;
+  --active-bg: #e8e8e8;
+  --focus-bg: #e0e0e0;
+  
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --shadow-hover: rgba(0, 0, 0, 0.2);
+  
+  --success-color: #4CAF50;
+  --warning-color: #ff9800;
+  --error-color: #f44336;
+  --info-color: #2196F3;
+}
+
+/* Red Theme */
+[data-theme="red"] {
+  --bg-primary: #1a0e0e;
+  --bg-secondary: #2a1616;
+  --bg-tertiary: #3a1f1f;
+  --bg-quaternary: #4a2828;
+  --bg-quinary: #5a3131;
+  
+  --text-primary: #ffffff;
+  --text-secondary: #ffcccc;
+  --text-tertiary: #ffaaaa;
+  --text-quaternary: #ff8888;
+  
+  --border-primary: #6a3a3a;
+  --border-secondary: #7a4a4a;
+  --border-tertiary: #8a5a5a;
+  --border-quaternary: #9a6a6a;
+  
+  --accent-primary: #ff4444;
+  --accent-secondary: #ff6b6b;
+  --accent-tertiary: #ff8a8a;
+  --accent-quaternary: #ffaaaa;
+  
+  --hover-bg: #4a2828;
+  --active-bg: #5a3131;
+  --focus-bg: #6a3a3a;
+  
+  --shadow-color: rgba(255, 68, 68, 0.3);
+  --shadow-hover: rgba(255, 68, 68, 0.5);
+  
+  --success-color: #4CAF50;
+  --warning-color: #ff9800;
+  --error-color: #ff4444;
+  --info-color: #2196F3;
+}
+
+/* Purple Theme */
+[data-theme="purple"] {
+  --bg-primary: #1a0e1a;
+  --bg-secondary: #2a162a;
+  --bg-tertiary: #3a1f3a;
+  --bg-quaternary: #4a284a;
+  --bg-quinary: #5a315a;
+  
+  --text-primary: #ffffff;
+  --text-secondary: #e1bee7;
+  --text-tertiary: #ce93d8;
+  --text-quaternary: #ba68c8;
+  
+  --border-primary: #6a3a6a;
+  --border-secondary: #7a4a7a;
+  --border-tertiary: #8a5a8a;
+  --border-quaternary: #9a6a9a;
+  
+  --accent-primary: #9c27b0;
+  --accent-secondary: #ba68c8;
+  --accent-tertiary: #ce93d8;
+  --accent-quaternary: #e1bee7;
+  
+  --hover-bg: #4a284a;
+  --active-bg: #5a315a;
+  --focus-bg: #6a3a6a;
+  
+  --shadow-color: rgba(156, 39, 176, 0.3);
+  --shadow-hover: rgba(156, 39, 176, 0.5);
+  
+  --success-color: #4CAF50;
+  --warning-color: #ff9800;
+  --error-color: #f44336;
+  --info-color: #9c27b0;
+}
+
+/* Blue Theme */
+[data-theme="blue"] {
+  --bg-primary: #0e1a2a;
+  --bg-secondary: #162a3a;
+  --bg-tertiary: #1f3a4a;
+  --bg-quaternary: #284a5a;
+  --bg-quinary: #315a6a;
+  
+  --text-primary: #ffffff;
+  --text-secondary: #bbdefb;
+  --text-tertiary: #90caf9;
+  --text-quaternary: #64b5f6;
+  
+  --border-primary: #3a6a7a;
+  --border-secondary: #4a7a8a;
+  --border-tertiary: #5a8a9a;
+  --border-quaternary: #6a9aaa;
+  
+  --accent-primary: #2196F3;
+  --accent-secondary: #42a5f5;
+  --accent-tertiary: #64b5f6;
+  --accent-quaternary: #90caf9;
+  
+  --hover-bg: #284a5a;
+  --active-bg: #315a6a;
+  --focus-bg: #3a6a7a;
+  
+  --shadow-color: rgba(33, 150, 243, 0.3);
+  --shadow-hover: rgba(33, 150, 243, 0.5);
+  
+  --success-color: #4CAF50;
+  --warning-color: #ff9800;
+  --error-color: #f44336;
+  --info-color: #2196F3;
+}
+
+/* Force theme attribute to take precedence */
+html[data-theme], body[data-theme] {
+  --theme-applied: true;
+}
+
+/* Dark Pop Theme - Neon Cyberpunk */
+[data-theme="darkpop"] {
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #111111;
+  --bg-tertiary: #1a1a1a;
+  --bg-quaternary: #222222;
+  --bg-quinary: #2a2a2a;
+  
+  --text-primary: #ffffff;
+  --text-secondary: #00ffff;
+  --text-tertiary: #ff00ff;
+  --text-quaternary: #00ff00;
+  
+  --border-primary: #ff00ff;
+  --border-secondary: #00ffff;
+  --border-tertiary: #00ff00;
+  --border-quaternary: #ffff00;
+  
+  --accent-primary: #ff00ff;
+  --accent-secondary: #00ffff;
+  --accent-tertiary: #00ff00;
+  --accent-quaternary: #ffff00;
+  
+  --hover-bg: #1a1a1a;
+  --active-bg: #222222;
+  --focus-bg: #2a2a2a;
+  
+  --shadow-color: rgba(255, 0, 255, 0.4);
+  --shadow-hover: rgba(0, 255, 255, 0.6);
+  
+  --success-color: #00ff00;
+  --warning-color: #ffff00;
+  --error-color: #ff0080;
+  --info-color: #00ffff;
 }
 
 .container {
@@ -71,17 +291,18 @@ body {
   gap: 1vw;
   margin-bottom: 1vh;
   padding: 0.5vw;
-  background: #2a2a2a;
+  background: var(--bg-quaternary);
   border-radius: 0.3vw;
-  border: 1px solid #444;
+  border: 1px solid var(--border-primary);
   width: 100%;
   box-sizing: border-box;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .drag-toggle-btn {
-  background: #444;
-  color: white;
-  border: 1px solid #666;
+  background: var(--bg-quinary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-tertiary);
   padding: 0.3vw 0.8vw;
   border-radius: 0.2vw;
   font-size: 0.8vw;
@@ -91,22 +312,22 @@ body {
 }
 
 .drag-toggle-btn:hover {
-  background: #555;
-  border-color: #777;
+  background: var(--hover-bg);
+  border-color: var(--border-quaternary);
 }
 
 .drag-toggle-btn.unlocked {
-  background: #ff6b6b;
-  border-color: #ff5252;
+  background: var(--accent-tertiary);
+  border-color: var(--accent-tertiary);
 }
 
 .drag-toggle-btn.unlocked:hover {
-  background: #ff5252;
-  border-color: #ff1744;
+  background: var(--accent-secondary);
+  border-color: var(--accent-secondary);
 }
 
 .drag-status {
-  color: #aaa;
+  color: var(--text-tertiary);
   font-size: 0.7vw;
   font-weight: 500;
 }
@@ -138,16 +359,17 @@ body {
   width: 100%;
 }
 .page-btn {
-  background: #333;
-  color: #fff;
-  border: 1px solid #555;
+  background: var(--bg-quinary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-secondary);
   padding: 6px 10px;
   border-radius: 6px;
   cursor: pointer;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
-.page-btn:hover { background: #444; }
+.page-btn:hover { background: var(--hover-bg); }
 .pagination-indicator {
-  color: #ccc;
+  color: var(--text-secondary);
   font-size: 13px;
   min-width: 80px;
   text-align: center;
@@ -160,10 +382,12 @@ body {
   transform: translateX(-50%);
   bottom: 18px;
   z-index: 9998;
-  background: rgba(20,20,20,0.6);
+  background: var(--bg-secondary);
   padding: 8px 12px;
   border-radius: 10px;
-  box-shadow: 0 6px 18px rgba(0,0,0,0.6);
+  box-shadow: 0 6px 18px var(--shadow-hover);
+  border: 1px solid var(--border-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 /* Add breathing room at the bottom of the main container so fixed pagination won't overlap content */
@@ -198,7 +422,7 @@ body {
 }
 
 .sound-card {
-  background: #333;
+  background: var(--bg-quinary);
   border-radius: 6px;
   padding: 8px;
   text-align: center;
@@ -223,9 +447,9 @@ body {
 }
 
 .sound-card:hover {
-  background: #444;
+  background: var(--hover-bg);
   transform: translateY(-2px);
-  border-color: #666;
+  border-color: var(--border-tertiary);
 }
 
 /* Drag and Drop Styles */
@@ -237,9 +461,9 @@ body {
 }
 
 .sound-card.draggable:hover {
-  background: #444;
+  background: var(--hover-bg);
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 8px var(--shadow-color);
 }
 
 .sound-card.dragging {
@@ -265,14 +489,14 @@ body {
 
 .sound-card:active {
   transform: translateY(0);
-  background: #555;
+  background: var(--active-bg);
 }
 
 .sound-name {
   font-weight: bold;
   font-size: 12px;
   margin-bottom: 4px;
-  color: white;
+  color: var(--text-primary);
   line-height: 1.2;
   word-break: break-word;
   overflow: hidden;
@@ -284,8 +508,8 @@ body {
 
 .sound-hotkey {
   font-size: 8px;
-  color: #ccc;
-  background: #222;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
   padding: 1px 4px;
   border-radius: 3px;
   margin-top: 2px;
@@ -293,20 +517,21 @@ body {
 
 .sound-type {
   font-size: 10px;
-  color: #888;
+  color: var(--text-quaternary);
   text-transform: uppercase;
   margin-bottom: 5px;
 }
 
 .add-card {
-  background: #2a2a2a;
-  border: 2px dashed #666;
-  color: #ccc;
+  background: var(--bg-quaternary);
+  border: 2px dashed var(--border-tertiary);
+  color: var(--text-secondary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .add-card:hover {
-  background: #3a3a3a;
-  border-color: #888;
+  background: var(--hover-bg);
+  border-color: var(--border-quaternary);
 }
 
 .add-icon {
@@ -441,13 +666,14 @@ body {
 }
 
 .modal-content {
-  background: #222;
+  background: var(--bg-tertiary);
   padding: 20px;
   border-radius: 10px;
-  color: white;
+  color: var(--text-primary);
   width: 400px;
   z-index: 10001; /* Make sure this is higher than the overlay */
   position: relative;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .modal-content input,
@@ -478,12 +704,13 @@ body {
 }
 
 #drop-zone {
-  border: 2px dashed #666;
+  border: 2px dashed var(--border-tertiary);
   padding: 10px;
   margin-top: 10px;
-  background: #1a1a1a;
-  color: #ccc;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   text-align: center;
+  transition: border-color 0.3s ease, background-color 0.3s ease, color 0.3s ease;
 }
 
 /* About modal specifics */
@@ -648,32 +875,33 @@ body {
   display: none !important;
 }
 
+
 /* Component Visibility Dropdown Styles */
 .visibility-dropdown {
   position: fixed;
   top: 10px;
-  right: 100px;
+  right: 60px;
   z-index: 3000;
   -webkit-app-region: no-drag;
   pointer-events: auto;
 }
 
 .visibility-toggle-btn {
-  background: #444;
-  color: #fff;
-  border: 1px solid #666;
+  background: var(--bg-quinary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-tertiary);
   padding: 8px 12px;
   border-radius: 8px;
   cursor: pointer;
   font-size: 14px;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  box-shadow: 0 2px 8px var(--shadow-color);
   opacity: 0.85;
 }
 
 .visibility-toggle-btn:hover {
-  background: #555;
-  border-color: #777;
+  background: var(--hover-bg);
+  border-color: var(--border-quaternary);
   opacity: 1;
 }
 
@@ -681,14 +909,15 @@ body {
   position: absolute;
   top: 100%;
   left: 0;
-  background: #222;
-  border: 1px solid #444;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
   border-radius: 8px;
   padding: 12px;
   min-width: 200px;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 16px var(--shadow-hover);
   z-index: 3001;
   pointer-events: auto;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .visibility-menu.hidden {
@@ -696,18 +925,18 @@ body {
 }
 
 .visibility-header {
-  color: #fff;
+  color: var(--text-primary);
   font-weight: bold;
   font-size: 14px;
   margin-bottom: 8px;
   padding-bottom: 8px;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .visibility-item {
   display: flex;
   align-items: center;
-  color: #ccc;
+  color: var(--text-secondary);
   font-size: 13px;
   margin: 6px 0;
   cursor: pointer;
@@ -724,21 +953,21 @@ body {
 }
 
 .visibility-item:hover {
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .visibility-actions {
   margin-top: 12px;
   padding-top: 8px;
-  border-top: 1px solid #444;
+  border-top: 1px solid var(--border-primary);
   display: flex;
   gap: 8px;
 }
 
 .visibility-action-btn {
-  background: #444;
-  color: #fff;
-  border: 1px solid #666;
+  background: var(--bg-quinary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-tertiary);
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
@@ -748,19 +977,19 @@ body {
 }
 
 .visibility-action-btn:hover {
-  background: #555;
-  border-color: #777;
+  background: var(--hover-bg);
+  border-color: var(--border-quaternary);
 }
 
 .version-info {
   margin-top: 12px;
   padding-top: 8px;
-  border-top: 1px solid #444;
+  border-top: 1px solid var(--border-primary);
   display: flex;
   justify-content: space-between;
   align-items: center;
   font-size: 12px;
-  color: #ccc;
+  color: var(--text-secondary);
   pointer-events: none;
   user-select: none;
 }
@@ -770,7 +999,7 @@ body {
 }
 
 .version-value {
-  color: #888;
+  color: var(--text-quaternary);
   font-family: monospace;
 }
 
@@ -792,21 +1021,22 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 }
 
 .hotkey-info {
-  background: #2a2a2a;
-  border: 1px solid #444;
+  background: var(--bg-quaternary);
+  border: 1px solid var(--border-primary);
   border-radius: 8px;
   padding: 8px 12px;
   margin: 10px 0;
   font-size: 12px;
-  color: #ccc;
+  color: var(--text-secondary);
   max-width: 400px;
   margin-left: auto;
   margin-right: auto;
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
 }
 
 .hotkey-help {
   margin-top: 5px;
-  color: #888;
+  color: var(--text-quaternary);
   font-style: italic;
 }
 
@@ -820,15 +1050,16 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
   left: 0;
   width: 100vw;
   height: 60px;
-  background: rgba(0,0,0,0.7);
-  color: #fff;
+  background: var(--bg-primary);
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
   pointer-events: all;
   font-size: 1.2em;
-  transition: background 0.2s;
+  transition: background-color 0.2s, color 0.2s;
+  opacity: 0.8;
 }
 #global-drop-zone.hidden {
   display: none;
@@ -846,8 +1077,8 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 
 /* Twitch Chat Display Styles */
 #twitch-chat-container {
-  background: #1a1a1a;
-  border: 1px solid #444;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
   border-radius: 0.5vw;
   width: 20vw;
   height: 40vh;
@@ -856,7 +1087,7 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
   max-width: 600px; /* Increased max-width to allow expansion */
   max-height: 600px;
   overflow: visible;
-  transition: width 0.3s ease, height 0.3s ease;
+  transition: width 0.3s ease, height 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
   flex-shrink: 0;
   flex-grow: 0; /* Don't grow automatically */
   display: flex;
@@ -885,15 +1116,16 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 }
 
 .chat-header {
-  background: #2a2a2a;
+  background: var(--bg-quaternary);
   padding: 8px 12px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
   height: 40px;
   box-sizing: border-box;
+  transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .chat-controls {
@@ -934,8 +1166,8 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 
 /* Twitch Statistics Display */
 #twitch-stats-container {
-  background: #1a1a1a;
-  border: 1px solid #333;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
   border-radius: 0.3vw;
   padding: 0.5vw;
   margin: 0.5vh 0;
@@ -1001,16 +1233,16 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
   align-items: center;
   justify-content: center;
   padding: 0.5vw;
-  background: #2a2a2a;
+  background: var(--bg-quaternary);
   border-radius: 0.3vw;
-  border: 1px solid #444;
+  border: 1px solid var(--border-primary);
   transition: all 0.2s ease;
   min-height: 3vh;
 }
 
 .stat-item:hover {
-  background: #333;
-  border-color: #555;
+  background: var(--hover-bg);
+  border-color: var(--border-secondary);
 }
 
 .stat-container {
@@ -1068,7 +1300,7 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 
 .stat-label {
   font-size: 0.7vw;
-  color: #aaa;
+  color: var(--text-tertiary);
   margin-bottom: 0.2vw;
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -1077,14 +1309,14 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 .stat-value {
   font-size: 1.1vw;
   font-weight: bold;
-  color: #fff;
+  color: var(--text-primary);
   font-family: 'Courier New', monospace;
 }
 
 /* Recent Activity Display */
 #recent-activity-container {
-  background: #1a1a1a;
-  border: 1px solid #333;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
   border-radius: 0.5vw;
   padding: 0.8vw 1vw;
   margin: 1vh 0;
@@ -1114,7 +1346,7 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 }
 
 .recent-label {
-  color: #888;
+  color: var(--text-quaternary);
   font-size: 13px;
   font-weight: 500;
   white-space: nowrap;
@@ -1123,7 +1355,7 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 }
 
 .recent-value {
-  color: #fff;
+  color: var(--text-primary);
   font-size: 13px;
   font-weight: bold;
   font-family: 'Courier New', monospace;
@@ -1213,14 +1445,14 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
 
 .chat-title {
   font-weight: bold;
-  color: #fff;
+  color: var(--text-primary);
   font-size: 14px;
 }
 
 .toggle-chat-btn {
-  background: #444;
+  background: var(--bg-quinary);
   border: none;
-  color: #fff;
+  color: var(--text-primary);
   width: 24px;
   height: 24px;
   border-radius: 4px;
@@ -1230,10 +1462,11 @@ button, input, select, textarea, label, #sound-grid, #add-sound-card, .sound-car
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background-color 0.3s ease;
 }
 
 .toggle-chat-btn:hover {
-  background: #666;
+  background: var(--hover-bg);
 }
 
 /* Chat Resize Handle */
@@ -1295,12 +1528,13 @@ body.resizing-chat * {
   line-height: 1.6;
   text-align: left;
   font-family: 'Courier New', monospace;
-  background: #1a1a1a;
+  background: var(--bg-secondary);
   min-height: 0;
   max-height: 360px;
   height: 100%;
   scrollbar-width: thin;
-  scrollbar-color: #444 #1a1a1a;
+  scrollbar-color: var(--border-primary) var(--bg-secondary);
+  transition: background-color 0.3s ease;
 }
 
 .chat-message {


### PR DESCRIPTION
- Move theme selection from floating button to Tools → Themes menu
- Add radio button theme options with icons (🌙 Dark, ☀️ Light, ❤️ Red, 💜 Purple, 💙 Blue, 🎵 Dark Pop)
- Implement bidirectional theme sync between UI and menu
- Add IPC handlers for theme-change and sync-theme events
- Ensure theme persistence works in both development and production
- Remove floating theme button UI and CSS
- Clean up debugging code and streamline theme manager
- Maintain hotkey support (Ctrl+Shift+T) for theme cycling